### PR TITLE
Added meta description 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="This is a uneven task progress card to show the progress of user's tasks"
+    />
     <title>Progress Card Demo</title>
   </head>
   <body>


### PR DESCRIPTION
#9 Added meta description

As you can see the lighthouse score increased and doesn't show meta description error
<img width="929" alt="image" src="https://user-images.githubusercontent.com/19698300/222917931-4eaa107b-f192-4cb4-ad2c-0d7ddb10f79c.png">
